### PR TITLE
fix trainer schedule start_time

### DIFF
--- a/services/trainerScheduleService.js
+++ b/services/trainerScheduleService.js
@@ -9,7 +9,7 @@ async function makeDateTimeTypeToOnlyDate (dateTimeType) {
 async function changeTrainerScheduleStartTime (trainerSchedules) {
     let trainerScheduleUpdatedStartTime = [];
     for (const trainerSchedule of trainerSchedules) {
-        trainerSchedule.start_time = moment(trainerSchedule.start_time).subtract(9, 'h').format('YYYY-MM-DD HH:mm:ss');
+        trainerSchedule.start_time = moment(trainerSchedule.start_time).format('YYYY-MM-DD HH:mm:ss');
         trainerScheduleUpdatedStartTime.push(trainerSchedule);
     }
     return trainerScheduleUpdatedStartTime;


### PR DESCRIPTION
- change start_time on trainer schedule object using moment
  - format 'YYYY-MM-DD HH:mm:ss'
  - fix 9 hour diff